### PR TITLE
Specify swift-syntax version in manifest

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,9 +23,9 @@
         "package": "SwiftSyntax",
         "repositoryURL": "https://github.com/apple/swift-syntax",
         "state": {
-          "branch": "main",
-          "revision": "dfb8deb846e16d98e1d5b2261ed608121e096037",
-          "version": null
+          "branch": null,
+          "revision": "6ad4ea24b01559dde0773e3d091f1b9e36175036",
+          "version": "509.0.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let docc: PackageDescription.Package.Dependency = .package(
 )
 let swiftSyntax = PackageDescription.Package.Dependency.package(
     url: "https://github.com/apple/swift-syntax",
-    branch: "main"
+    from: "509.0.2"
 )
 
 let package = Package(


### PR DESCRIPTION
Specified a `swift-syntax` version in the `Package.swift` manifest to resolve an error when trying to add `csv2img` to a project.